### PR TITLE
fix data transfer error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mm-dapp-react",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mm-dapp-react",
-      "version": "0.0.0",
+      "version": "1.0.0",
       "dependencies": {
         "@metamask/detect-provider": "^2.0.0",
         "react": "^18.2.0",
@@ -4828,8 +4828,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ajv": {
       "version": "6.12.6",
@@ -5374,8 +5373,7 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
       "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-plugin-unused-imports": {
       "version": "3.0.0",
@@ -6561,15 +6559,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.1.tgz",
       "integrity": "sha512-lC/RGlPmwdrIBFTX59wwNzqh7aR2otPNPR/5brHZm/XKFYKsfqxihXUe9pU3JI+3vGkl+vyCoNNnPhJn3aLK1A==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "tsconfck": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-2.1.1.tgz",
       "integrity": "sha512-ZPCkJBKASZBmBUNqGHmRhdhM8pJYDdOXp4nRgj/O0JwUwsMq50lCDRQP/M5GBNAA0elPrq4gAeu4dkaVCuKWww==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "type-check": {
       "version": "0.4.0",

--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -24,7 +24,7 @@ export const Navigation = () => {
           {hasProvider && wallet.accounts.length > 0 &&
             <a
               className="text_link tooltip-bottom"
-              href={`https://etherscan.io/address/${wallet}`}
+              href={`https://etherscan.io/address/${wallet.accounts[0]}`}
               target="_blank"
               data-tooltip="Open in Block Explorer" rel="noreferrer"
             >


### PR DESCRIPTION
If one wanted to press the link in the header to Etherscan with the logged in account, the {wallet} object was forwarded, leading to this forwarding link "https://etherscan.io/address/[object%20Object]". To fix this error, {wallet.accounts[0]} had to be taken. Now instead of an object, the currently connected wallet address would be forwarded to Etherscan. 